### PR TITLE
Automatically publish to Maven when new release is created

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,58 @@
+# Automatically generate Release Notes.
+# ~~~~~~~~~~~~~
+changelog:
+  exclude:
+    labels:
+      - "Type: Ignore"
+      - "type:ignore"
+  
+  categories:
+    - title: "Breaking Changes 🚨"
+      labels:
+        - "Type: Breaking Change"
+        - "type:breaking-change"
+
+    - title: "Amazing New Features ✨"
+      labels:
+        - "Type: Feature"
+        - "type:feature"
+        
+    - title: "Feature Improvements 👨‍💻"
+      labels:
+        - "Type: Enhancement"
+        - "type:enhancement"
+
+    - title: "Hotfixes 🔥"
+      labels:
+        - "Type: Hotfix"
+        - "type:hotfix"
+
+    - title: "Fixing Bugs 🐛"
+      labels:
+        - "Type: Bug"
+        - "type:bug"
+
+    - title: "Maintain Project 🤝"
+      labels:
+        - "Type: Maintainance"
+        - "type:maintainance"
+        - "Type: Docs"
+        - "type:docs"
+        - "Type: Doc"
+        - "type:doc"
+
+    - title: "Dependencies Changes ⬆️⬇️"
+      labels:
+        - "Type: Dependency"
+        - "type:dependency"
+
+    - title: "Improve Security 🚔"
+      labels:
+        - "Type: Security"
+        - "type:security"
+        - "security fix"
+        - "security vulnerability"
+
+    - title: "Other Changes 🛠"
+      labels:
+        - "*"

--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -1,0 +1,28 @@
+# publish to Maven when a new release is made
+# ~~
+name: CD
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    name: Publish to Maven
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: '11'
+          cache: 'sbt'
+
+      - name: Publish package
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ val scala3 = "3.2.2"
 
 ThisBuild / organization := "io.cequence"
 ThisBuild / scalaVersion := scala212
-ThisBuild / version := "0.3.3"
+//handled by cbt-ci-release
+//ThisBuild / version := "0.3.3"
 ThisBuild / isSnapshot := false
 
 lazy val core = (project in file("openai-core"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import sbt.Keys.test
 
+enablePlugins(Common)
+
 // Supported versions
 val scala212 = "2.12.15"
 val scala213 = "2.13.10"
@@ -46,3 +48,32 @@ ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
+
+addCommandAlias(
+  "validateCode",
+  List(
+    "scalafix",
+    "scalafmtSbtCheck",
+    "scalafmtCheckAll",
+    "test:scalafix",
+    "test:scalafmtCheckAll"
+  ).mkString(";")
+)
+
+addCommandAlias(
+  "formatCode",
+  List(
+    "scalafmt",
+    "scalafmtSbt",
+    "Test/scalafmt"
+  ).mkString(";")
+)
+
+addCommandAlias(
+  "testWithCoverage",
+  List(
+    "coverage",
+    "test",
+    "coverageReport"
+  ).mkString(";")
+)

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+object Common extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = JvmPlugin
+
+  val gitAccount = "cequence-io"
+  val repoName = "openai-scala-client"
+
+  override def globalSettings: Seq[Setting[_]] =
+    Seq(
+      // project
+      description := "Scala client for OpenAI API",
+      // organization
+      organization := "cequence.io",
+      organizationName := "Cequence",
+      organizationHomepage := Some(
+        url(s"https://github.com/$gitAccount/$repoName")
+      ),
+     // legal
+      licenses := Seq(
+        "MIT" ->
+          url(s"https://github.com/$gitAccount/$repoName/blob/main/LICENSE")
+      ),
+      // on the web
+      homepage := Some(url(s"https://github.com/$gitAccount/$repoName")),
+      developers += Developer(
+        "contributors",
+        "Contributors",
+        s"https://github.com/$gitAccount/$repoName/graphs/contributors",
+        url(s"https://github.com/$gitAccount")
+      )
+    )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,6 @@ logLevel := Level.Warn
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+// This is an sbt plugin to help automate releases to Sonatype and Maven Central from GitHub Actions.
+// See more: https://github.com/sbt/sbt-ci-release
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")


### PR DESCRIPTION
- configured [sbt-ci-release](https://github.com/sbt/sbt-ci-release)  plugin to automate publishing to Maven 

This requires the following [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to be created:

~~~
PGP_PASSPHRASE 
PGP_SECRET 
SONATYPE_PASSWORD 
SONATYPE_USERNAME 
~~~

Obviously I can't test this my end, but give me a shout if it doesn't work and I'll see if I can help.
