### PR TITLE
Install sbt-coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,3 +45,32 @@ ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
+
+addCommandAlias(
+  "validateCode",
+  List(
+    "scalafix",
+    "scalafmtSbtCheck",
+    "scalafmtCheckAll",
+    "test:scalafix",
+    "test:scalafmtCheckAll"
+  ).mkString(";")
+)
+
+addCommandAlias(
+  "formatCode",
+  List(
+    "scalafmt",
+    "scalafmtSbt",
+    "Test/scalafmt"
+  ).mkString(";")
+)
+
+addCommandAlias(
+  "testWithCoverage",
+  List(
+    "coverage",
+    "test",
+    "coverageReport"
+  ).mkString(";")
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,9 @@ logLevel := Level.Warn
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+
+// Test Coverage plugin.
+// ~
+// sbt-scoverage is a plugin for SBT that integrates the scoverage code coverage library.
+// See more: https://github.com/scoverage/sbt-scoverage
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")


### PR DESCRIPTION
can now run `sbt testWithCoverage` to generate coverage reports (see also #24)