### PR TITLE
add gpt-4-turbo, gpt-4-turbo-vision, gpt-3-5-turbo-1106 models to ModelId

### DIFF
--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
@@ -110,6 +110,8 @@ object ModelId {
   val gpt_3_5_turbo_16k_0613 = "gpt-3.5-turbo-16k-0613"
   val gpt_3_5_turbo_instruct_0914 = "gpt-3.5-turbo-instruct-0914"
   val gpt_3_5_turbo_instruct = "gpt-3.5-turbo-instruct"
+  // 16k context , gpt_3_5_turbo will point to this model from Dec 11, 2023
+  val gpt_3_5_turbo_1106 = "gpt-3.5-turbo-1106"
 
   // GPT-4
 

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
@@ -125,6 +125,11 @@ object ModelId {
   val gpt_4_32k_0314 = "gpt-4-32k-0314"
   // 32k context (June 13th snapshot), fine-tuned for function calling
   val gpt_4_32k_0613 = "gpt-4-32k-0613"
+  // 128K context (with training data upto April 2023)
+  val gpt_4_turbo_preview = "gpt-4-1106-preview"
+  // 128K context (with training data upto April 2023)
+  // includes supports for vision in addition to gpt-4-turbo capabilities
+  val gpt_4_vision_preview = "gpt-4-vision-preview"
 
   // Other
   @Deprecated


### PR DESCRIPTION
Adds supports for GPT-4-Turbo and GPT-4-Turbo-Vision models released today. 

This will enable 128K tokens context windows, and an updated training date of April 2023.

Also adds gpt-3-5-turbo-1106 model.