### PR TITLE
Avoid repetition in Open AI service 

### DIFF
--- a/openai-client/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
@@ -308,13 +308,13 @@ object JsonFormats {
   implicit val assistantToolFunctionFormat: Format[AssistantTool.Function] =
     Json.format[AssistantTool.Function]
 
+  implicit val functionToolFormat: Format[AssistantTool.FunctionTool] =
+    (JsPath \ "function")
+      .format[AssistantTool.Function]
+      .inmap[AssistantTool.FunctionTool](AssistantTool.FunctionTool.apply, _.function)
+
   implicit val assistantToolFormat: Format[AssistantTool] = {
     val typeDiscriminatorKey = "type"
-
-    val functionToolFormat: Format[AssistantTool.FunctionTool] =
-      (JsPath \ "function")
-        .format[AssistantTool.Function]
-        .inmap[AssistantTool.FunctionTool](AssistantTool.FunctionTool.apply, _.function)
 
     Format[AssistantTool](
       (json: JsValue) => {
@@ -338,10 +338,10 @@ object JsonFormats {
     )
   }
 
-  implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
-
   implicit val assistantIdFormat: Format[AssistantId] = Json.valueFormat[AssistantId]
 
-  implicit val assistantFileFormat: Format[AssistantFile] = Json.format[AssistantFile]
+  implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
+
+  lazy implicit val assistantFileFormat: Format[AssistantFile] = Json.format[AssistantFile]
 
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
@@ -338,7 +338,10 @@ object JsonFormats {
     )
   }
 
-  implicit val assistantFormat: Format[Assistant] =
-    Json.format[Assistant]
+  implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
+
+  implicit val assistantIdFormat: Format[AssistantId] = Json.valueFormat[AssistantId]
+
+  implicit val assistantFileFormat: Format[AssistantFile] = Json.format[AssistantFile]
 
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/EndPoint.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/EndPoint.scala
@@ -85,6 +85,7 @@ object Param {
   case object metadata extends Param
   case object role extends Param
   case object content extends Param
+  case object file_id extends Param
   case object file_ids extends Param
   case object order extends Param
   case object before extends Param

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -732,30 +732,6 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
     }
   }
 
-  /**
-   * Returns a list of assistant files.
-   *
-   * @param assistantId
-   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and
-   *   the default is 20.
-   * @param limit
-   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
-   *   for descending order.
-   * @param order
-   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
-   *   for descending order.
-   * @param after
-   *   A cursor for use in pagination. after is an object ID that defines your place in the
-   *   list. For instance, if you make a list request and receive 100 objects, ending with
-   *   `obj_foo`, your subsequent call can include `after=obj_foo` in order to fetch the next
-   *   page of the list.
-   * @param before
-   *   A cursor for use in pagination. before is an object ID that defines your place in the
-   *   list. For instance, if you make a list request and receive 100 objects, ending with
-   *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
-   *   previous page of the list.
-   * @return
-   */
   override def listAssistantFiles(
     assistantId: String,
     limit: Option[Int],
@@ -780,5 +756,13 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
             s"The attribute 'data' is not present in the response: ${response.toString()}."
           )
         )
+    }
+
+  override def retrieveAssistant(assistantId: String): Future[Option[Assistant]] =
+    execGETWithStatus(
+      EndPoint.assistants,
+      Some(assistantId)
+    ).map { response =>
+      handleNotFoundAndError(response).map(_.asSafe[Assistant])
     }
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -810,4 +810,55 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
       handleNotFoundAndError(response).map(_.asSafe[Assistant])
     }
 
+  override def deleteAssistant(assistantId: String): Future[DeleteResponse] =
+    execDELETEWithStatus(
+      EndPoint.assistants,
+      endPointParam = Some(assistantId)
+    ).map(response =>
+      handleNotFoundAndError(response)
+        .map(jsResponse =>
+          (jsResponse \ "deleted").toOption.map {
+            _.asSafe[Boolean] match {
+              case true  => DeleteResponse.Deleted
+              case false => DeleteResponse.NotDeleted
+            }
+          }.getOrElse(
+            throw new OpenAIScalaClientException(
+              s"The attribute 'deleted' is not present in the response: ${response.toString()}."
+            )
+          )
+        )
+        .getOrElse(
+          // we got a not-found http code (404)
+          DeleteResponse.NotFound
+        )
+    )
+
+  override def deleteAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[DeleteResponse] =
+    execDELETEWithStatus(
+      EndPoint.assistants,
+      endPointParam = Some(s"$assistantId/files/$fileId")
+    ).map(response =>
+      handleNotFoundAndError(response)
+        .map(jsResponse =>
+          (jsResponse \ "deleted").toOption.map {
+            _.asSafe[Boolean] match {
+              case true  => DeleteResponse.Deleted
+              case false => DeleteResponse.NotDeleted
+            }
+          }.getOrElse(
+            throw new OpenAIScalaClientException(
+              s"The attribute 'deleted' is not present in the response: ${response.toString()}."
+            )
+          )
+        )
+        .getOrElse(
+          // we got a not-found http code (404)
+          DeleteResponse.NotFound
+        )
+    )
+
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -732,4 +732,53 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
     }
   }
 
+  /**
+   * Returns a list of assistant files.
+   *
+   * @param assistantId
+   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and
+   *   the default is 20.
+   * @param limit
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
+   *   for descending order.
+   * @param order
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
+   *   for descending order.
+   * @param after
+   *   A cursor for use in pagination. after is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `after=obj_foo` in order to fetch the next
+   *   page of the list.
+   * @param before
+   *   A cursor for use in pagination. before is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
+   *   previous page of the list.
+   * @return
+   */
+  override def listAssistantFiles(
+    assistantId: String,
+    limit: Option[Int],
+    order: Option[SortOrder],
+    after: Option[String],
+    before: Option[String]
+  ): Future[Seq[AssistantFile]] =
+    execGET(
+      EndPoint.assistants,
+      endPointParam = Some(s"$assistantId/files"),
+      params = Seq(
+        Param.limit -> limit,
+        Param.order -> order,
+        Param.after -> after,
+        Param.before -> before
+      )
+    ).map { response =>
+      (response.asSafe[JsObject] \ "data").toOption
+        .map(_.asSafeArray[AssistantFile])
+        .getOrElse(
+          throw new OpenAIScalaClientException(
+            s"The attribute 'data' is not present in the response: ${response.toString()}."
+          )
+        )
+    }
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -707,4 +707,29 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
     ).map(_.asSafe[AssistantFile])
   }
 
+  override def listAssistants(
+    limit: Option[Int],
+    order: Option[SortOrder],
+    after: Option[String],
+    before: Option[String]
+  ): Future[Seq[Assistant]] = {
+    execGET(
+      EndPoint.assistants,
+      params = Seq(
+        Param.limit -> limit,
+        Param.order -> order,
+        Param.after -> after,
+        Param.before -> before
+      )
+    ).map { response =>
+      (response.asSafe[JsObject] \ "data").toOption
+        .map(_.asSafeArray[Assistant])
+        .getOrElse(
+          throw new OpenAIScalaClientException(
+            s"The attribute 'data' is not present in the response: ${response.toString()}."
+          )
+        )
+    }
+  }
+
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -677,7 +677,7 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
     description: Option[String],
     instructions: Option[String],
     tools: Seq[AssistantTool],
-    fileIds: Seq[FileId],
+    fileIds: Seq[String],
     metadata: Map[String, String]
   ): Future[Assistant] = {
     execPOST(
@@ -692,6 +692,19 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
         Param.metadata -> (if (metadata.nonEmpty) Some(metadata) else None)
       )
     ).map(_.asSafe[Assistant])
+  }
+
+  override def createAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[AssistantFile] = {
+    execPOST(
+      EndPoint.assistants,
+      endPointParam = Some(s"$assistantId/files"),
+      bodyParams = jsonBodyParams(
+        Param.file_id -> Some(fileId)
+      )
+    ).map(_.asSafe[AssistantFile])
   }
 
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceImpl.scala
@@ -765,4 +765,21 @@ private trait OpenAIServiceImpl extends OpenAICoreServiceImpl with OpenAIService
     ).map { response =>
       handleNotFoundAndError(response).map(_.asSafe[Assistant])
     }
+
+  /**
+   * Retrieves an AssistantFile.
+   *
+   * @param assistantId
+   * The ID of the assistant who the file belongs to.
+   * @param fileId
+   * The ID of the file we're getting.
+   */
+  override def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]] =
+    execGETWithStatus(
+      EndPoint.assistants,
+      Some(s"$assistantId/files/$fileId")
+    ).map { response =>
+      handleNotFoundAndError(response).map(_.asSafe[AssistantFile])
+    }
+
 }

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/ws/WSRequestHelper.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/ws/WSRequestHelper.scala
@@ -431,7 +431,8 @@ trait WSRequestHelper extends WSHelper {
 
   protected def handleNotFoundAndError[T](response: RichResponse[T]): Option[T] =
     response match {
-      case Left(value) => Some(value)
+      case Left(value) =>
+        Some(value)
 
       case Right((errorCode, _)) =>
         if (errorCode == 404) None

--- a/openai-client/src/test/scala/io/cequence/openaiscala/JsonFormatsSpec.scala
+++ b/openai-client/src/test/scala/io/cequence/openaiscala/JsonFormatsSpec.scala
@@ -1,6 +1,6 @@
 package io.cequence.openaiscala
 
-import io.cequence.openaiscala.domain.AssistantTool
+import io.cequence.openaiscala.domain.{AssistantTool, FileId}
 import io.cequence.openaiscala.domain.AssistantTool.CodeInterpreterTool
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -40,6 +40,10 @@ class JsonFormatsSpec extends AnyWordSpecLike with Matchers {
       val function = AssistantTool.Function("description", "name", Some("parameters"))
       testCodec[AssistantTool](AssistantTool.FunctionTool(function), functionToolJson, Pretty)
     }
+
+//    "serialize and deserialize a file ID" in {
+//      testCodec(FileId("some-file-id"), """"some-file-id"""")
+//    }
 
   }
 

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/Assistant.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/Assistant.scala
@@ -1,0 +1,3 @@
+package io.cequence.openaiscala.domain
+
+final case class AssistantId(id: String) extends AnyVal

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/AssistantTool.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/AssistantTool.scala
@@ -28,7 +28,7 @@ object AssistantTool {
     // FIXME: description should be optional in request and mandatory in response
     description: String,
     name: String,
-    parameters: Option[String]
+    parameters: Option[String] // TODO: check representation
   )
 
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/response/Assistant.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/response/Assistant.scala
@@ -1,12 +1,12 @@
 package io.cequence.openaiscala.domain.response
 
-import io.cequence.openaiscala.domain.{AssistantTool, EnumValue, FileId}
+import io.cequence.openaiscala.domain.{AssistantId, AssistantTool, EnumValue, FileId}
 
 import java.{util => ju}
 
 final case class Assistant(
   // The identifier, which can be referenced in API endpoints.
-  id: String,
+  id: AssistantId,
 
   // TODO: check whether ChatRole.Assistant can be used here?
   // The object type, which is always assistant.
@@ -23,7 +23,7 @@ final case class Assistant(
 
   // ID of the model to use. You can use the List models API to see all of your available models,
   // or see our Model overview for descriptions of them.
-  model: String,
+  model: String, // TODO: check whether ModelId can be used here?
 
   // The system instructions that the assistant uses. The maximum length is 32768 characters.
   instructions: Option[String],

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/response/AssistantFile.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/response/AssistantFile.scala
@@ -1,0 +1,16 @@
+package io.cequence.openaiscala.domain.response
+
+import io.cequence.openaiscala.domain.{AssistantId, FileId}
+
+import java.{util => ju}
+
+final case class AssistantFile(
+  // The identifier, which can be referenced in API endpoints.
+  id: FileId,
+  // The object type, which is always assistant.file.
+  `object`: String,
+  // The Unix timestamp (in seconds) for when the assistant file was created.
+  created_at: ju.Date,
+  // The assistant ID that the file is attached to.
+  assistant_id: AssistantId
+)

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -768,6 +768,8 @@ trait OpenAIService extends OpenAICoreService {
   ): Future[AssistantFile]
 
   /**
+   * Returns a list of assistants.
+   *
    * @param limit
    *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and
    *   the default is 20.
@@ -792,5 +794,32 @@ trait OpenAIService extends OpenAICoreService {
     after: Option[String] = None,
     before: Option[String] = None
   ): Future[Seq[Assistant]]
+
+  /**
+   * Returns a list of assistant files.
+   *
+   * @param assistantId
+   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
+   * @param limit
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.
+   * @param order
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.
+   * @param after
+   *   A cursor for use in pagination. after is an object ID that defines your place in the list. For instance,
+   *   if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include
+   *   `after=obj_foo` in order to fetch the next page of the list.
+   * @param before
+   *   A cursor for use in pagination. before is an object ID that defines your place in the list. For instance,
+   *   if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include
+   *   `before=obj_foo` in order to fetch the previous page of the list.
+   * @return
+   */
+  def listAssistantFiles(
+    assistantId: String,
+    limit: Option[Int] = None,
+    order: Option[SortOrder] = None,
+    after: Option[String] = None,
+    before: Option[String] = None
+  ): Future[Seq[AssistantFile]]
 
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -760,7 +760,10 @@ trait OpenAIService extends OpenAICoreService {
    * @param fileId
    *   A File ID (with purpose="assistants") that the assistant should use. Useful for tools
    *   like `retrieval` and `code_interpreter` that can access files.
-   * @return
+   * @see
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/createAssistantFile">OpenAI
+   *   Doc</a>
    */
   def createAssistantFile(
     assistantId: String,
@@ -786,6 +789,10 @@ trait OpenAIService extends OpenAICoreService {
    *   list. For instance, if you make a list request and receive 100 objects, ending with
    *   `obj_foo`, your subsequent call can include `before=obj_foo`` in order to fetch the
    *   previous page of the list.
+   * @see
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/listAssistants">OpenAI
+   *   Doc</a>
    */
   def listAssistants(
     limit: Option[Int] = None, // TODO: default 20 or None?
@@ -817,6 +824,9 @@ trait OpenAIService extends OpenAICoreService {
    *   list. For instance, if you make a list request and receive 100 objects, ending with
    *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
    *   previous page of the list.
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/listAssistantFiles">OpenAI
+   *   Doc</a>
    */
   def listAssistantFiles(
     assistantId: String,
@@ -831,6 +841,9 @@ trait OpenAIService extends OpenAICoreService {
    *
    * @param assistantId
    *   The ID of the assistant to retrieve.
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/retrieveAssistant">OpenAI
+   *   Doc</a>
    */
   def retrieveAssistant(assistantId: String): Future[Option[Assistant]]
 
@@ -841,7 +854,49 @@ trait OpenAIService extends OpenAICoreService {
    *   The ID of the assistant who the file belongs to.
    * @param fileId
    *   The ID of the file we're getting.
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/retrieveAssistantFile">OpenAI
+   *   Doc</a>
    */
   def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]]
+
+  /**
+   * Modifies an assistant.
+   *
+   * @param assistantId
+   * @param model
+   *   ID of the model to use. You can use the List models API to see all of your available models,
+   *   or see our Model overview for descriptions of them.
+   * @param name
+   *   The name of the assistant. The maximum length is 256 characters.
+   * @param description
+   *   The description of the assistant. The maximum length is 512 characters.
+   * @param instructions
+   *   The system instructions that the assistant uses. The maximum length is 32768 characters.
+   * @param tools
+   *   A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types
+   *   code_interpreter, retrieval, or function.
+   * @param fileIds
+   *   A list of File IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant.
+   *   Files are ordered by their creation date in ascending order. If a file was previously attached to the list but
+   *   does not show up in the list, it will be deleted from the assistant.
+   * @param metadata
+   *   Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional
+   *   information about the object in a structured format. Keys can be a maximum of 64 characters long and values
+   *   can be a maxium of 512 characters long.
+   *   <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/modifyAssistant">OpenAI
+   *   Doc</a>
+   */
+  def modifyAssistant(
+    assistantId: String,
+    model: Option[String] = None,
+    name: Option[String] = None,
+    description: Option[String] = None,
+    instructions: Option[String] = None,
+    tools: Seq[AssistantTool] = Seq.empty[AssistantTool],
+    fileIds: Seq[String] = Seq.empty,
+    metadata: Map[String, String] = Map.empty
+  ): Future[Option[Assistant]]
 
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -823,8 +823,7 @@ trait OpenAIService extends OpenAICoreService {
    *   A cursor for use in pagination. before is an object ID that defines your place in the
    *   list. For instance, if you make a list request and receive 100 objects, ending with
    *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
-   *   previous page of the list.
-   *   <a
+   *   previous page of the list. <a
    *   href="https://platform.openai.com/docs/api-reference/assistants/listAssistantFiles">OpenAI
    *   Doc</a>
    */
@@ -840,8 +839,7 @@ trait OpenAIService extends OpenAICoreService {
    * Retrieves an assistant.
    *
    * @param assistantId
-   *   The ID of the assistant to retrieve.
-   *   <a
+   *   The ID of the assistant to retrieve. <a
    *   href="https://platform.openai.com/docs/api-reference/assistants/retrieveAssistant">OpenAI
    *   Doc</a>
    */
@@ -853,20 +851,22 @@ trait OpenAIService extends OpenAICoreService {
    * @param assistantId
    *   The ID of the assistant who the file belongs to.
    * @param fileId
-   *   The ID of the file we're getting.
-   *   <a
+   *   The ID of the file we're getting. <a
    *   href="https://platform.openai.com/docs/api-reference/assistants/retrieveAssistantFile">OpenAI
    *   Doc</a>
    */
-  def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]]
+  def retrieveAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[Option[AssistantFile]]
 
   /**
    * Modifies an assistant.
    *
    * @param assistantId
    * @param model
-   *   ID of the model to use. You can use the List models API to see all of your available models,
-   *   or see our Model overview for descriptions of them.
+   *   ID of the model to use. You can use the List models API to see all of your available
+   *   models, or see our Model overview for descriptions of them.
    * @param name
    *   The name of the assistant. The maximum length is 256 characters.
    * @param description
@@ -874,17 +874,17 @@ trait OpenAIService extends OpenAICoreService {
    * @param instructions
    *   The system instructions that the assistant uses. The maximum length is 32768 characters.
    * @param tools
-   *   A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types
-   *   code_interpreter, retrieval, or function.
+   *   A list of tool enabled on the assistant. There can be a maximum of 128 tools per
+   *   assistant. Tools can be of types code_interpreter, retrieval, or function.
    * @param fileIds
-   *   A list of File IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant.
-   *   Files are ordered by their creation date in ascending order. If a file was previously attached to the list but
-   *   does not show up in the list, it will be deleted from the assistant.
+   *   A list of File IDs attached to this assistant. There can be a maximum of 20 files
+   *   attached to the assistant. Files are ordered by their creation date in ascending order.
+   *   If a file was previously attached to the list but does not show up in the list, it will
+   *   be deleted from the assistant.
    * @param metadata
-   *   Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional
-   *   information about the object in a structured format. Keys can be a maximum of 64 characters long and values
-   *   can be a maxium of 512 characters long.
-   *   <a
+   *   Set of 16 key-value pairs that can be attached to an object. This can be useful for
+   *   storing additional information about the object in a structured format. Keys can be a
+   *   maximum of 64 characters long and values can be a maxium of 512 characters long. <a
    *   href="https://platform.openai.com/docs/api-reference/assistants/modifyAssistant">OpenAI
    *   Doc</a>
    */
@@ -898,5 +898,30 @@ trait OpenAIService extends OpenAICoreService {
     fileIds: Seq[String] = Seq.empty,
     metadata: Map[String, String] = Map.empty
   ): Future[Option[Assistant]]
+
+  /**
+   * Delete an assistant.
+   *
+   * @param assistantId
+   *   The ID of the assistant to delete. <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/deleteAssistant">OpenAI
+   *   Doc</a>
+   */
+  def deleteAssistant(assistantId: String): Future[DeleteResponse]
+
+  /**
+   * Delete an assistant file.
+   *
+   * @param assistantId
+   *   The ID of the assistant that the file belongs to.
+   * @param fileId
+   *   The ID of the file to delete. <a
+   *   href="https://platform.openai.com/docs/api-reference/assistants/deleteAssistantFile">OpenAI
+   *   Doc</a>
+   */
+  def deleteAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[DeleteResponse]
 
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -834,4 +834,14 @@ trait OpenAIService extends OpenAICoreService {
    */
   def retrieveAssistant(assistantId: String): Future[Option[Assistant]]
 
+  /**
+   * Retrieves an AssistantFile.
+   *
+   * @param assistantId
+   *   The ID of the assistant who the file belongs to.
+   * @param fileId
+   *   The ID of the file we're getting.
+   */
+  def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]]
+
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -817,7 +817,6 @@ trait OpenAIService extends OpenAICoreService {
    *   list. For instance, if you make a list request and receive 100 objects, ending with
    *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
    *   previous page of the list.
-   * @return
    */
   def listAssistantFiles(
     assistantId: String,
@@ -826,5 +825,13 @@ trait OpenAIService extends OpenAICoreService {
     after: Option[String] = None,
     before: Option[String] = None
   ): Future[Seq[AssistantFile]]
+
+  /**
+   * Retrieves an assistant.
+   *
+   * @param assistantId
+   *   The ID of the assistant to retrieve.
+   */
+  def retrieveAssistant(assistantId: String): Future[Option[Assistant]]
 
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -748,7 +748,23 @@ trait OpenAIService extends OpenAICoreService {
     description: Option[String] = None,
     instructions: Option[String] = None,
     tools: Seq[AssistantTool] = Seq.empty[AssistantTool],
-    fileIds: Seq[FileId] = Seq.empty,
+    fileIds: Seq[String] = Seq.empty,
     metadata: Map[String, String] = Map.empty
   ): Future[Assistant]
+
+  /**
+   * Create an assistant file by attaching a File to an assistant.
+   *
+   * @param assistantId
+   *   The ID of the assistant for which to create a File.
+   * @param fileId
+   *   A File ID (with purpose="assistants") that the assistant should use. Useful for tools
+   *   like `retrieval` and `code_interpreter` that can access files.
+   * @return
+   */
+  def createAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[AssistantFile]
+
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -767,4 +767,30 @@ trait OpenAIService extends OpenAICoreService {
     fileId: String
   ): Future[AssistantFile]
 
+  /**
+   * @param limit
+   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and
+   *   the default is 20.
+   * @param order
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
+   *   for descending order.
+   * @param after
+   *   A cursor for use in pagination. after is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `after=obj_foo` in order to fetch the next
+   *   page of the list.
+   * @param before
+   *   A cursor for use in pagination. before is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `before=obj_foo`` in order to fetch the
+   *   previous page of the list.
+   */
+  def listAssistants(
+    limit: Option[Int] = None, // TODO: default 20 or None?
+    // FIXME: not very nice API, high cohesion among these params, should be enclosed as e.g. Pagination
+    order: Option[SortOrder] = None,
+    after: Option[String] = None,
+    before: Option[String] = None
+  ): Future[Seq[Assistant]]
+
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIService.scala
@@ -799,19 +799,24 @@ trait OpenAIService extends OpenAICoreService {
    * Returns a list of assistant files.
    *
    * @param assistantId
-   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
+   *   A limit on the number of objects to be returned. Limit can range between 1 and 100, and
+   *   the default is 20.
    * @param limit
-   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
+   *   for descending order.
    * @param order
-   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.
+   *   Sort order by the created_at timestamp of the objects. asc for ascending order and desc
+   *   for descending order.
    * @param after
-   *   A cursor for use in pagination. after is an object ID that defines your place in the list. For instance,
-   *   if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include
-   *   `after=obj_foo` in order to fetch the next page of the list.
+   *   A cursor for use in pagination. after is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `after=obj_foo` in order to fetch the next
+   *   page of the list.
    * @param before
-   *   A cursor for use in pagination. before is an object ID that defines your place in the list. For instance,
-   *   if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include
-   *   `before=obj_foo` in order to fetch the previous page of the list.
+   *   A cursor for use in pagination. before is an object ID that defines your place in the
+   *   list. For instance, if you make a list request and receive 100 objects, ending with
+   *   `obj_foo`, your subsequent call can include `before=obj_foo` in order to fetch the
+   *   previous page of the list.
    * @return
    */
   def listAssistantFiles(

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -300,11 +300,19 @@ trait OpenAIServiceWrapper extends OpenAIService {
     description: Option[String],
     instructions: Option[String],
     tools: Seq[AssistantTool],
-    fileIds: Seq[FileId],
+    fileIds: Seq[String],
     metadata: Map[String, String]
   ): Future[Assistant] = wrap(
     _.createAssistant(model, name, description, instructions, tools, fileIds, metadata)
   )
+
+  override def createAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[AssistantFile] =
+    wrap(
+      _.createAssistantFile(assistantId, fileId)
+    )
 
   protected def wrap[T](
     fun: OpenAIService => Future[T]

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -335,6 +335,9 @@ trait OpenAIServiceWrapper extends OpenAIService {
       _.listAssistantFiles(assistantId, limit, order, after, before)
     )
 
+  override def retrieveAssistant(assistantId: String): Future[Option[Assistant]] =
+    wrap(_.retrieveAssistant(assistantId))
+
   protected def wrap[T](
     fun: OpenAIService => Future[T]
   ): Future[T]

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -314,6 +314,16 @@ trait OpenAIServiceWrapper extends OpenAIService {
       _.createAssistantFile(assistantId, fileId)
     )
 
+  override def listAssistants(
+    limit: Option[Int],
+    order: Option[SortOrder],
+    after: Option[String],
+    before: Option[String]
+  ): Future[Seq[Assistant]] =
+    wrap(
+      _.listAssistants(limit, order, after, before)
+    )
+
   protected def wrap[T](
     fun: OpenAIService => Future[T]
   ): Future[T]

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -338,8 +338,34 @@ trait OpenAIServiceWrapper extends OpenAIService {
   override def retrieveAssistant(assistantId: String): Future[Option[Assistant]] =
     wrap(_.retrieveAssistant(assistantId))
 
-  override def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]] =
+  override def retrieveAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[Option[AssistantFile]] =
     wrap(_.retrieveAssistantFile(assistantId, fileId))
+
+  override def modifyAssistant(
+    assistantId: String,
+    model: Option[String],
+    name: Option[String],
+    description: Option[String],
+    instructions: Option[String],
+    tools: Seq[AssistantTool],
+    fileIds: Seq[String],
+    metadata: Map[String, String]
+  ): Future[Option[Assistant]] =
+    wrap(
+      _.modifyAssistant(
+        assistantId,
+        model,
+        name,
+        description,
+        instructions,
+        tools,
+        fileIds,
+        metadata
+      )
+    )
 
   protected def wrap[T](
     fun: OpenAIService => Future[T]

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -338,6 +338,9 @@ trait OpenAIServiceWrapper extends OpenAIService {
   override def retrieveAssistant(assistantId: String): Future[Option[Assistant]] =
     wrap(_.retrieveAssistant(assistantId))
 
+  override def retrieveAssistantFile(assistantId: String, fileId: String): Future[Option[AssistantFile]] =
+    wrap(_.retrieveAssistantFile(assistantId, fileId))
+
   protected def wrap[T](
     fun: OpenAIService => Future[T]
   ): Future[T]

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -367,7 +367,17 @@ trait OpenAIServiceWrapper extends OpenAIService {
       )
     )
 
+  override def deleteAssistant(assistantId: String): Future[DeleteResponse] =
+    wrap(_.deleteAssistant(assistantId))
+
+  override def deleteAssistantFile(
+    assistantId: String,
+    fileId: String
+  ): Future[DeleteResponse] =
+    wrap(_.deleteAssistantFile(assistantId, fileId))
+
   protected def wrap[T](
     fun: OpenAIService => Future[T]
   ): Future[T]
+
 }

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/OpenAIServiceWrapper.scala
@@ -324,6 +324,17 @@ trait OpenAIServiceWrapper extends OpenAIService {
       _.listAssistants(limit, order, after, before)
     )
 
+  override def listAssistantFiles(
+    assistantId: String,
+    limit: Option[Int],
+    order: Option[SortOrder],
+    after: Option[String],
+    before: Option[String]
+  ): Future[Seq[AssistantFile]] =
+    wrap(
+      _.listAssistantFiles(assistantId, limit, order, after, before)
+    )
+
   protected def wrap[T](
     fun: OpenAIService => Future[T]
   ): Future[T]

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistant.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistant.scala
@@ -1,5 +1,5 @@
 package io.cequence.openaiscala.examples
-import io.cequence.openaiscala.domain.{AssistantTool, ModelId}
+import io.cequence.openaiscala.domain.{AssistantTool, FileId, ModelId}
 
 import scala.concurrent.Future
 
@@ -12,6 +12,7 @@ object CreateAssistant extends Example {
         instructions = Some(
           "You are a personal math tutor. When asked a question, write and run Python code to answer the question."
         ),
+        fileIds = Seq("file-id"),
         tools = Seq(AssistantTool.CodeInterpreterTool)
       )
     } yield println(assistant)

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistantFile.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistantFile.scala
@@ -1,5 +1,4 @@
 package io.cequence.openaiscala.examples
-import io.cequence.openaiscala.domain.FileId
 
 import scala.concurrent.Future
 
@@ -8,7 +7,7 @@ object CreateAssistantFile extends Example {
   override protected def run: Future[_] =
     for {
       assistantFile <- service.createAssistantFile(
-        assistantId = "assistant-id",
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8",
         fileId = "file"
       )
     } yield println(assistantFile)

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistantFile.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateAssistantFile.scala
@@ -1,0 +1,16 @@
+package io.cequence.openaiscala.examples
+import io.cequence.openaiscala.domain.FileId
+
+import scala.concurrent.Future
+
+object CreateAssistantFile extends Example {
+
+  override protected def run: Future[_] =
+    for {
+      assistantFile <- service.createAssistantFile(
+        assistantId = "assistant-id",
+        fileId = "file"
+      )
+    } yield println(assistantFile)
+
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateThreadMessage.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/CreateThreadMessage.scala
@@ -9,6 +9,7 @@ object CreateThreadMessage extends Example {
       message <- service.createThreadMessage(
         threadId = "thread_c6fFMmUw30l30SzG2KdUViMn",
         content = "Hello, what is AI really?",
+        fileIds = Seq("file-1", "file-2"),
         metadata = Map("user_id" -> Random.nextInt().toString)
       )
     } yield {

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/DeleteAssistant.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/DeleteAssistant.scala
@@ -1,0 +1,13 @@
+package io.cequence.openaiscala.examples
+
+object DeleteAssistant extends Example {
+
+  override protected def run =
+    for {
+      thread <- service.deleteAssistant(
+        "asst_Btbc2h7dqyDU52g1KfBa2XE9"
+      )
+    } yield {
+      println(thread)
+    }
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/DeleteAssistantFile.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/DeleteAssistantFile.scala
@@ -1,0 +1,14 @@
+package io.cequence.openaiscala.examples
+
+object DeleteAssistantFile extends Example {
+
+  override protected def run =
+    for {
+      thread <- service.deleteAssistantFile(
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8",
+        fileId = "file_0123"
+      )
+    } yield {
+      println(thread)
+    }
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ListAssistantFiles.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ListAssistantFiles.scala
@@ -1,0 +1,15 @@
+package io.cequence.openaiscala.examples
+import scala.concurrent.Future
+
+object ListAssistantFiles extends Example {
+
+  override protected def run: Future[_] =
+    for {
+      assistantFiles <- service.listAssistantFiles(
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8",
+        limit = Some(5)
+      )
+    } yield {
+      assistantFiles.foreach(println)
+    }
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ListAssistants.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ListAssistants.scala
@@ -1,0 +1,13 @@
+package io.cequence.openaiscala.examples
+import scala.concurrent.Future
+
+object ListAssistants extends Example {
+
+  override protected def run: Future[_] =
+    for {
+      assistants <- service.listAssistants(limit = Some(5))
+    } yield {
+      assistants.foreach(println)
+    }
+
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ModifyAssistant.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ModifyAssistant.scala
@@ -1,0 +1,14 @@
+package io.cequence.openaiscala.examples
+
+object ModifyAssistant extends Example {
+
+  override protected def run =
+    for {
+      thread <- service.modifyAssistant(
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8",
+        metadata = Map("user_id" -> "986415", "due_date" -> "2028-08-01")
+      )
+    } yield {
+      println(thread)
+    }
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/RetrieveAssistant.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/RetrieveAssistant.scala
@@ -1,0 +1,15 @@
+package io.cequence.openaiscala.examples
+import scala.concurrent.Future
+
+object RetrieveAssistant extends Example {
+
+  override protected def run: Future[_] =
+    for {
+      assistant <- service.retrieveAssistant(
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8"
+      )
+    } yield {
+      println(assistant)
+    }
+
+}

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/RetrieveAssistantFile.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/RetrieveAssistantFile.scala
@@ -1,0 +1,17 @@
+package io.cequence.openaiscala.examples
+
+import scala.concurrent.Future
+
+object RetrieveAssistantFile extends Example {
+
+  override protected def run: Future[_] =
+    for {
+      assistant <- service.retrieveAssistantFile(
+        assistantId = "asst_Btbc2h7dqyDU52g1KfBa2XE8",
+        fileId = "file_2bX"
+      )
+    } yield {
+      println(assistant)
+    }
+
+}


### PR DESCRIPTION
Let service methods speak at the same level of abstraction.

Response handling polluted service methods with low level details, in particular:
- reading attributes from response and 
- interpreting delete endpoint responses

Thus, it has been extracted and reused to avoid repetition and potential errors.