### PR TITLE
Token count polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,24 +365,57 @@ For this to work you need to use `OpenAIServiceStreamedFactory` from `openai-sca
 
 - 🔥 **New**: Count expected used tokens before calling `createChatCompletions` or `createChatFunCompletions`, this helps you select proper model ex. `gpt-3.5-turbo` or `gpt-3.5-turbo-16k` and reduce costs. This is an experimental feature and it may not work for all models. Requires `openai-scala-count-tokens` lib.
 
+An example how to count message tokens:
+```scala
+import io.cequence.openaiscala.domain.{AssistantMessage, BaseMessage, FunctionSpec, ModelId, SystemMessage, UserMessage}
+
+class MyCompletionService extends OpenAICountTokensHelper {
+  def exec = {
+    val model = ModelId.gpt_4_turbo_2024_04_09
+
+    // messages to be sent to OpenAI
+    val messages: Seq[BaseMessage] = Seq(
+      SystemMessage("You are a helpful assistant."),
+      UserMessage("Who won the world series in 2020?"),
+      AssistantMessage("The Los Angeles Dodgers won the World Series in 2020."),
+      UserMessage("Where was it played?"),
+    )
+
+    val tokens = countMessageTokens(model, messages)
+  }
+}
+```
+
+An example how to count message tokens when a function is involved:
 ```scala
 import io.cequence.openaiscala.service.OpenAICountTokensHelper
 import io.cequence.openaiscala.domain.{ChatRole, FunMessageSpec, FunctionSpec}
 
+// TODO: simpler example
+import io.cequence.openaiscala.domain.{BaseMessage, FunctionSpec, ModelId, SystemMessage, UserMessage}
+
 class MyCompletionService extends OpenAICountTokensHelper {
   def exec = {
-    val messages: Seq[FunMessageSpec] = ??? // messages to be sent to OpenAI
+    val model = ModelId.gpt_4_turbo_2024_04_09
+    
+    // messages to be sent to OpenAI
+    val messages: Seq[BaseMessage] = 
+     Seq(
+       SystemMessage("You are a helpful assistant."),
+       UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?")
+     )
+     
     // function to be called
     val function: FunctionSpec = FunctionSpec(
       name = "getWeather",
       parameters = Map(
         "type" -> "object",
-        "properties" -> ListMap(
-          "location" -> ListMap(
+        "properties" -> Map(
+          "location" -> Map(
             "type" -> "string",
             "description" -> "The city to get the weather for"
           ),
-          "unit" -> ListMap("type" -> "string", "enum" -> List("celsius", "fahrenheit"))
+          "unit" -> Map("type" -> "string", "enum" -> List("celsius", "fahrenheit"))
         )
       )
     )

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ For this to work you need to use `OpenAIServiceStreamedFactory` from `openai-sca
   }
 ```
 
-- 🔥 **New**: Count expected used tokens before calling `createChatCompletions` or `createChatFunCompletions`, this help you select proper model ex. `gpt-3.5-turbo` or `gpt-3.5-turbo-16k` and reduce costs. This is an experimental feature and it may not work for all models. Requires `openai-scala-count-tokens` lib.
+- 🔥 **New**: Count expected used tokens before calling `createChatCompletions` or `createChatFunCompletions`, this helps you select proper model ex. `gpt-3.5-turbo` or `gpt-3.5-turbo-16k` and reduce costs. This is an experimental feature and it may not work for all models. Requires `openai-scala-count-tokens` lib.
 
 ```scala
 import io.cequence.openaiscala.service.OpenAICountTokensHelper
@@ -372,7 +372,20 @@ import io.cequence.openaiscala.domain.{ChatRole, FunMessageSpec, FunctionSpec}
 class MyCompletionService extends OpenAICountTokensHelper {
   def exec = {
     val messages: Seq[FunMessageSpec] = ??? // messages to be sent to OpenAI
-    val function: FunctionSpec = ??? // function to be called
+    // function to be called
+    val function: FunctionSpec = FunctionSpec(
+      name = "getWeather",
+      parameters = Map(
+        "type" -> "object",
+        "properties" -> ListMap(
+          "location" -> ListMap(
+            "type" -> "string",
+            "description" -> "The city to get the weather for"
+          ),
+          "unit" -> ListMap("type" -> "string", "enum" -> List("celsius", "fahrenheit"))
+        )
+      )
+    )
 
     val tokens = countFunMessageTokens(model, messages, Seq(function), Some(function.name))
   }

--- a/openai-count-tokens/README.md
+++ b/openai-count-tokens/README.md
@@ -27,16 +27,25 @@ or to *pom.xml* (if you use maven)
 
 ## Usage
 
+An example how to count message tokens:
 ```scala
-import io.cequence.openaiscala.service.OpenAICountTokensHelper
-import io.cequence.openaiscala.domain.{ChatRole, FunMessageSpec, FunctionSpec}
+import io.cequence.openaiscala.domain.{AssistantMessage, BaseMessage, FunctionSpec, ModelId, SystemMessage, UserMessage}
 
-val messages: Seq[FunMessageSpec] = ??? // messages to be sent to OpenAI
-val function: FunctionSpec = ??? // function to be called
+class MyCompletionService extends OpenAICountTokensHelper {
+  def exec = {
+    val model = ModelId.gpt_4_turbo_2024_04_09
 
-val service = new OpenAICountTokensService()
+    // messages to be sent to OpenAI
+    val messages: Seq[BaseMessage] = Seq(
+      SystemMessage("You are a helpful assistant."),
+      UserMessage("Who won the world series in 2020?"),
+      AssistantMessage("The Los Angeles Dodgers won the World Series in 2020."),
+      UserMessage("Where was it played?"),
+    )
 
-val tokens = service.countFunMessageTokens(messages, List(function), Some(function.name))
+    val tokens = countMessageTokens(model, messages)
+  }
+}
 ```
 
 

--- a/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
+++ b/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
@@ -53,12 +53,12 @@ trait OpenAICountTokensHelper {
         // every message follows <|start|>{role/name}\n{content}<|end|>\n
         // if there's a name, the role is omitted
         (4, -1)
-      case ModelId.gpt_3_5_turbo_0613 | ModelId.gpt_3_5_turbo_16k_0613 | ModelId.gpt_4_0314 | ModelId.gpt_4_32k_0314 |
-          ModelId.gpt_4_0613 | ModelId.gpt_4_32k_0613 =>
+      case ModelId.gpt_3_5_turbo_0613 | ModelId.gpt_3_5_turbo_16k_0613 | ModelId.gpt_4_0314 |
+          ModelId.gpt_4_32k_0314 | ModelId.gpt_4_0613 | ModelId.gpt_4_32k_0613 =>
         (3, 1)
       case ModelId.gpt_3_5_turbo => tokensPerMessageAndName(ModelId.gpt_3_5_turbo_0613)
       case ModelId.gpt_4         => tokensPerMessageAndName(ModelId.gpt_4_0613)
-      case _               =>
+      case _                     =>
         // failover to (3, 1)
         (3, 1)
     }

--- a/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
+++ b/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
@@ -53,8 +53,8 @@ trait OpenAICountTokensHelper {
         // every message follows <|start|>{role/name}\n{content}<|end|>\n
         // if there's a name, the role is omitted
         (4, -1)
-      case ModelId.gpt_3_5_turbo_0613 | ModelId.gpt_3_5_turbo_16k_0613 | ModelId.gpt_4_0314 |
-          ModelId.gpt_4_32k_0314 | ModelId.gpt_4_0613 | ModelId.gpt_4_32k_0613 =>
+      case ModelId.gpt_3_5_turbo_0613 | ModelId.gpt_3_5_turbo_16k_0613 | ModelId.gpt_4_0613 |
+          ModelId.gpt_4_32k_0613 | ModelId.gpt_4_turbo_2024_04_09 =>
         (3, 1)
       case ModelId.gpt_3_5_turbo => tokensPerMessageAndName(ModelId.gpt_3_5_turbo_0613)
       case ModelId.gpt_4         => tokensPerMessageAndName(ModelId.gpt_4_0613)

--- a/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
+++ b/openai-count-tokens/src/main/scala/io/cequence/openaiscala/service/OpenAICountTokensHelper.scala
@@ -49,15 +49,15 @@ trait OpenAICountTokensHelper {
 
   private def tokensPerMessageAndName(model: String): (Int, Int) =
     model match {
-      case "gpt-3.5-turbo-0301" =>
+      case ModelId.gpt_3_5_turbo_0301 =>
         // every message follows <|start|>{role/name}\n{content}<|end|>\n
         // if there's a name, the role is omitted
         (4, -1)
-      case "gpt-3.5-turbo-0613" | "gpt-3.5-turbo-16k-0613" | "gpt-4-0314" | "gpt-4-32k-0314" |
-          "gpt-4-0613" | "gpt-4-32k-0613" =>
+      case ModelId.gpt_3_5_turbo_0613 | ModelId.gpt_3_5_turbo_16k_0613 | ModelId.gpt_4_0314 | ModelId.gpt_4_32k_0314 |
+          ModelId.gpt_4_0613 | ModelId.gpt_4_32k_0613 =>
         (3, 1)
-      case "gpt-3.5-turbo" => tokensPerMessageAndName("gpt-3.5-turbo-0613")
-      case "gpt-4"         => tokensPerMessageAndName("gpt-4-0613")
+      case ModelId.gpt_3_5_turbo => tokensPerMessageAndName(ModelId.gpt_3_5_turbo_0613)
+      case ModelId.gpt_4         => tokensPerMessageAndName(ModelId.gpt_4_0613)
       case _               =>
         // failover to (3, 1)
         (3, 1)

--- a/openai-count-tokens/src/test/scala/io/cequence/openaiscala/service/OpenAICountTokensServiceSpec.scala
+++ b/openai-count-tokens/src/test/scala/io/cequence/openaiscala/service/OpenAICountTokensServiceSpec.scala
@@ -16,7 +16,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{BeforeAndAfterAll, Ignore}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable.ListMap
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/openai-count-tokens/src/test/scala/io/cequence/openaiscala/service/OpenAICountTokensServiceSpec.scala
+++ b/openai-count-tokens/src/test/scala/io/cequence/openaiscala/service/OpenAICountTokensServiceSpec.scala
@@ -4,9 +4,8 @@ import akka.testkit.TestKit
 import io.cequence.openaiscala.domain.{
   AssistantMessage,
   BaseMessage,
-  ChatRole,
   FunctionSpec,
-  MessageSpec,
+  ModelId,
   SystemMessage,
   UserMessage
 }
@@ -102,7 +101,7 @@ class OpenAICountTokensServiceSpec
       messages: Seq[BaseMessage],
       expectedTokens: Int,
       responseFunctionName: Option[String] = None,
-      model: String = "gpt-3.5-turbo"
+      model: String = ModelId.gpt_3_5_turbo
     ): Unit = {
       val countedTokens = countFunMessageTokens(
         model,
@@ -142,32 +141,32 @@ class OpenAICountTokensServiceSpec
       "You are a helpful consultant assisting with the translation of corporate jargon into plain English."
     )
 
-    // TODO: add gpt-4-turno-2024-04-09, gpt-4-0125-preview, gpt-4-1106-preview
+    // TODO: add gpt-4-turbo-2024-04-09, gpt-4-0125-preview, gpt-4-1106-preview
     "count tokens for a system message" in new TestCase {
       checkTokensForMessageCall(
         chat(systemMessage),
-        "gpt-4-turno-2024-04-09" -> 24,
-        "gpt-4-1106-preview" -> 24,
-        "gpt-4-0613" -> 24,
-        "gpt-4-0125-preview" -> 24,
-        "gpt-4" -> 24,
-        "gpt-3.5-turbo" -> 24,
-        "gpt-3.5-turbo-0301" -> 25,
-        "gpt-3.5-turbo-0613" -> 24
+        ModelId.gpt_4_turbo_2024_04_09 -> 24,
+        ModelId.gpt_4_1106_preview -> 24,
+        ModelId.gpt_4_0613 -> 24,
+        ModelId.gpt_4_0125_preview -> 24,
+        ModelId.gpt_4 -> 24,
+        ModelId.gpt_3_5_turbo -> 24,
+        ModelId.gpt_3_5_turbo_0301 -> 25,
+        ModelId.gpt_3_5_turbo_0613 -> 24
       )
     }
 
     "count tokens for a named system message" in new TestCase {
       checkTokensForMessageCall(
         chat(systemMessage.withName("James")),
-        "gpt-4-turno-2024-04-09" -> 26,
-        "gpt-4-1106-preview" -> 26,
-        "gpt-4-0613" -> 26,
-        "gpt-4-0125-preview" -> 26,
-        "gpt-4" -> 26,
-        "gpt-3.5-turbo" -> 26,
-        "gpt-3.5-turbo-0301" -> 25,
-        "gpt-3.5-turbo-0613" -> 26
+        ModelId.gpt_4_turbo_2024_04_09 -> 26,
+        ModelId.gpt_4_1106_preview -> 26,
+        ModelId.gpt_4_0613 -> 26,
+        ModelId.gpt_4_0125_preview -> 26,
+        ModelId.gpt_4 -> 26,
+        ModelId.gpt_3_5_turbo -> 26,
+        ModelId.gpt_3_5_turbo_0301 -> 25,
+        ModelId.gpt_3_5_turbo_0613 -> 26
       )
     }
 
@@ -178,28 +177,28 @@ class OpenAICountTokensServiceSpec
     "count tokens for a user message" in new TestCase {
       checkTokensForMessageCall(
         chat(userMessage),
-        "gpt-4-turno-2024-04-09" -> 33,
-        "gpt-4-1106-preview" -> 33,
-        "gpt-4-0613" -> 33,
-        "gpt-4-0125-preview" -> 33,
-        "gpt-4" -> 33,
-        "gpt-3.5-turbo" -> 33,
-        "gpt-3.5-turbo-0301" -> 34,
-        "gpt-3.5-turbo-0613" -> 33
+        ModelId.gpt_4_turbo_2024_04_09 -> 33,
+        ModelId.gpt_4_1106_preview -> 33,
+        ModelId.gpt_4_0613 -> 33,
+        ModelId.gpt_4_0125_preview -> 33,
+        ModelId.gpt_4 -> 33,
+        ModelId.gpt_3_5_turbo -> 33,
+        ModelId.gpt_3_5_turbo_0301 -> 34,
+        ModelId.gpt_3_5_turbo_0613 -> 33
       )
     }
 
     "count tokens for a user message with name" in new TestCase {
       checkTokensForMessageCall(
         chat(userMessage.withName("Alice")),
-        "gpt-4-turno-2024-04-09" -> 35,
-        "gpt-4-1106-preview" -> 35,
-        "gpt-4-0613" -> 35,
-        "gpt-4-0125-preview" -> 35,
-        "gpt-4" -> 35,
-        "gpt-3.5-turbo" -> 35,
-        "gpt-3.5-turbo-0301" -> 34,
-        "gpt-3.5-turbo-0613" -> 35
+        ModelId.gpt_4_turbo_2024_04_09 -> 35,
+        ModelId.gpt_4_1106_preview -> 35,
+        ModelId.gpt_4_0613 -> 35,
+        ModelId.gpt_4_0125_preview -> 35,
+        ModelId.gpt_4 -> 35,
+        ModelId.gpt_3_5_turbo -> 35,
+        ModelId.gpt_3_5_turbo_0301 -> 34,
+        ModelId.gpt_3_5_turbo_0613 -> 35
       )
     }
 
@@ -210,56 +209,56 @@ class OpenAICountTokensServiceSpec
     "count tokens for an assistant message" in new TestCase {
       checkTokensForMessageCall(
         chat(assistantMessage),
-        "gpt-4-turno-2024-04-09" -> 44,
-        "gpt-4-1106-preview" -> 44,
-        "gpt-4-0613" -> 44,
-        "gpt-4-0125-preview" -> 44,
-        "gpt-4" -> 44,
-        "gpt-3.5-turbo" -> 44,
-        "gpt-3.5-turbo-0301" -> 45,
-        "gpt-3.5-turbo-0613" -> 44
+        ModelId.gpt_4_turbo_2024_04_09 -> 44,
+        ModelId.gpt_4_1106_preview -> 44,
+        ModelId.gpt_4_0613 -> 44,
+        ModelId.gpt_4_0125_preview -> 44,
+        ModelId.gpt_4 -> 44,
+        ModelId.gpt_3_5_turbo -> 44,
+        ModelId.gpt_3_5_turbo_0301 -> 45,
+        ModelId.gpt_3_5_turbo_0613 -> 44
       )
     }
 
     "count tokens for an assistant message with name" in new TestCase {
       checkTokensForMessageCall(
         chat(assistantMessage.withName("Bob")),
-        "gpt-4-turno-2024-04-09" -> 46,
-        "gpt-4-1106-preview" -> 46,
-        "gpt-4-0613" -> 46,
-        "gpt-4-0125-preview" -> 46,
-        "gpt-4" -> 46,
-        "gpt-3.5-turbo" -> 46,
-        "gpt-3.5-turbo-0301" -> 45,
-        "gpt-3.5-turbo-0613" -> 46
+        ModelId.gpt_4_turbo_2024_04_09 -> 46,
+        ModelId.gpt_4_1106_preview -> 46,
+        ModelId.gpt_4_0613 -> 46,
+        ModelId.gpt_4_0125_preview -> 46,
+        ModelId.gpt_4 -> 46,
+        ModelId.gpt_3_5_turbo -> 46,
+        ModelId.gpt_3_5_turbo_0301 -> 45,
+        ModelId.gpt_3_5_turbo_0613 -> 46
       )
     }
 
     "count tokens of a chat with two messages" in new TestCase {
       checkTokensForMessageCall(
         chat(systemMessage, userMessage),
-        "gpt-4-turno-2024-04-09" -> 54,
-        "gpt-4-1106-preview" -> 54,
-        "gpt-4-0613" -> 54,
-        "gpt-4-0125-preview" -> 54,
-        "gpt-4" -> 54,
-        "gpt-3.5-turbo" -> 54,
-        "gpt-3.5-turbo-0301" -> 56,
-        "gpt-3.5-turbo-0613" -> 54
+        ModelId.gpt_4_turbo_2024_04_09 -> 54,
+        ModelId.gpt_4_1106_preview -> 54,
+        ModelId.gpt_4_0613 -> 54,
+        ModelId.gpt_4_0125_preview -> 54,
+        ModelId.gpt_4 -> 54,
+        ModelId.gpt_3_5_turbo -> 54,
+        ModelId.gpt_3_5_turbo_0301 -> 56,
+        ModelId.gpt_3_5_turbo_0613 -> 54
       )
     }
 
     "count tokens of a chat with two messages with names" in new TestCase {
       checkTokensForMessageCall(
         chat(systemMessage.withName("James"), userMessage.withName("Alice")),
-        "gpt-4-turno-2024-04-09" -> 58,
-        "gpt-4-1106-preview" -> 58,
-        "gpt-4-0613" -> 58,
-        "gpt-4-0125-preview" -> 58,
-        "gpt-4" -> 58,
-        "gpt-3.5-turbo" -> 58,
-        "gpt-3.5-turbo-0301" -> 56,
-        "gpt-3.5-turbo-0613" -> 58
+        ModelId.gpt_4_turbo_2024_04_09 -> 58,
+        ModelId.gpt_4_1106_preview -> 58,
+        ModelId.gpt_4_0613 -> 58,
+        ModelId.gpt_4_0125_preview -> 58,
+        ModelId.gpt_4 -> 58,
+        ModelId.gpt_3_5_turbo -> 58,
+        ModelId.gpt_3_5_turbo_0301 -> 56,
+        ModelId.gpt_3_5_turbo_0613 -> 58
       )
     }
 
@@ -285,14 +284,14 @@ class OpenAICountTokensServiceSpec
     "count tokens of a chat with multiple messages" in new TestCase {
       checkTokensForMessageCall(
         openAICookbookTestCaseMessages,
-        "gpt-4-turno-2024-04-09" -> 129,
-        "gpt-4-1106-preview" -> 129,
-        "gpt-4-0613" -> 129,
-        "gpt-4-0125-preview" -> 129,
-        "gpt-4" -> 129,
-        "gpt-3.5-turbo" -> 129,
-        "gpt-3.5-turbo-0301" -> 127,
-        "gpt-3.5-turbo-0613" -> 129
+        ModelId.gpt_4_turbo_2024_04_09 -> 129,
+        ModelId.gpt_4_1106_preview -> 129,
+        ModelId.gpt_4_0613 -> 129,
+        ModelId.gpt_4_0125_preview -> 129,
+        ModelId.gpt_4 -> 129,
+        ModelId.gpt_3_5_turbo -> 129,
+        ModelId.gpt_3_5_turbo_0301 -> 127,
+        ModelId.gpt_3_5_turbo_0613 -> 129
       )
     }
 
@@ -495,7 +494,7 @@ class OpenAICountTokensServiceSpec
         Seq(function1),
         messages,
         expectedTokens = 46,
-        model = "gpt-4"
+        model = ModelId.gpt_4
       )
     }
 
@@ -522,7 +521,7 @@ class OpenAICountTokensServiceSpec
 
       val messages: Seq[BaseMessage] = Seq(UserMessage("hello"))
 
-      private val model = "gpt-3.5-turbo"
+      private val model = ModelId.gpt_3_5_turbo
       private val responseFunctionName = Some("function")
       checkTokensForFunctionCall(
         Seq(function1),
@@ -566,7 +565,7 @@ class OpenAICountTokensServiceSpec
 
       val messages: Seq[BaseMessage] = Seq(UserMessage("hello"))
 
-      private val model = "gpt-3.5-turbo"
+      private val model = ModelId.gpt_3_5_turbo
       private val responseFunctionName = Some("function")
       checkTokensForFunctionCall(
         Seq(function1),


### PR DESCRIPTION
Polish token counting. Use `ModelId` constants instead of plain String literals and add examples to README-s.