### PR TITLE
Fixes AssistantToolMessage's json reads

### DIFF
--- a/openai-core/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/JsonFormats.scala
@@ -101,14 +101,14 @@ object JsonFormats {
   implicit val assistantToolMessageReads: Reads[AssistantToolMessage] = (
     (__ \ "content").readNullable[String] and
       (__ \ "name").readNullable[String] and
-      (__ \ "tool_calls").read[JsArray]
+      (__ \ "tool_calls").readNullable[JsArray]
   ) {
     (
       content,
       name,
       tool_calls
     ) =>
-      val idToolCalls = tool_calls.value.toSeq.map { toolCall =>
+      val idToolCalls = tool_calls.getOrElse(JsArray()).value.map { toolCall =>
         val callId = (toolCall \ "id").as[String]
         val callType = (toolCall \ "type").as[String]
         val call: ToolCallSpec = callType match {


### PR DESCRIPTION
Fixes "Cannot be parsed due to: JSON at path '/choices(0)/message/too……l_calls' contains the following errors: error.path.missing"

Even though OpenAI response schema defines tool_calls as being an array, that field might be absent in response if the output is generated text and not function call