### PR TITLE
fix: use max_completion_tokens for OpenAI

### DIFF
--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/impl/EndPoint.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/impl/EndPoint.scala
@@ -34,6 +34,7 @@ object Param {
   case object model extends Param
   case object prompt extends Param
   case object suffix extends Param
+  @Deprecated
   case object max_tokens extends Param
   case object temperature extends Param
   case object top_p extends Param

--- a/openai-client/src/main/scala/io/cequence/openaiscala/service/impl/OpenAIChatCompletionServiceImpl.scala
+++ b/openai-client/src/main/scala/io/cequence/openaiscala/service/impl/OpenAIChatCompletionServiceImpl.scala
@@ -114,7 +114,7 @@ trait ChatCompletionBodyMaker {
           case _ => Some(settingsFinal.stop)
         }
       },
-      Param.max_tokens -> settingsFinal.max_tokens,
+      Param.max_completion_tokens -> settingsFinal.max_tokens,
       Param.presence_penalty -> settingsFinal.presence_penalty,
       Param.frequency_penalty -> settingsFinal.frequency_penalty,
       Param.logit_bias -> {

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/ModelId.scala
@@ -134,6 +134,12 @@ object ModelId {
   val canary_tts = "canary-tts"
   val canary_whisper = "canary-whisper"
 
+  val gpt_5 = "gpt-5"
+  val gpt_5_2025_08_07 = "gpt-5-2025-08-07"
+  val gpt_5_nano = "gpt-5-nano"
+  val gpt_5_mini = "gpt-5-mini"
+  val gpt_5_mini_2025_08_07 = "gpt-5-mini-2025-08-07"
+
   val gpt_4o_mini_transcribe = "gpt-4o-mini-transcribe"
   val gpt_4o_mini_audio_preview = "gpt-4o-mini-audio-preview"
   val gpt_4o_mini_vision_preview = "gpt-4o-mini-vision-preview"

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/adapter/ChatCompletionSettingsConversions.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/adapter/ChatCompletionSettingsConversions.scala
@@ -35,17 +35,6 @@ object ChatCompletionSettingsConversions {
     }
 
   private val oBaseConversions = Seq(
-    // max tokens
-    FieldConversionDef(
-      _.max_tokens.isDefined,
-      settings =>
-        settings.copy(
-          max_tokens = None,
-          extra_params =
-            settings.extra_params + ("max_completion_tokens" -> settings.max_tokens.get)
-        ),
-      Some("O models don't support max_tokens, converting to max_completion_tokens")
-    ),
     // temperature
     FieldConversionDef(
       settings => settings.temperature.isDefined && settings.temperature.get != 1,


### PR DESCRIPTION
fixes #100

Looks like `maxTokens` is deprecated in favor of `maxCompletionTokens` and they are the same thing.

This PR won't change any interfaces or introduce anything new, it doesn't even help with GPT-5 compatibility, it just allows the models to run and then clients can figure out which fields they'd like to use with the new model.