### PR TITLE
Add support for the instructions array you receive when using createM…

### DIFF
--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/responsesapi/Response.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/responsesapi/Response.scala
@@ -74,7 +74,7 @@ final case class Response(
   error: Option[ResponseError] = None,
   id: String,
   incompleteDetails: Option[IncompleteDetails] = None,
-  instructions: Option[String] = None,
+  instructions: Option[Seq[Message]] = None,
   maxOutputTokens: Option[Int] = None,
   metadata: Option[Map[String, String]] = None,
   model: String,

--- a/openai-core/src/test/scala/io/cequence/openaiscala/domain/responsesapi/JsonFormatsSpecs.scala
+++ b/openai-core/src/test/scala/io/cequence/openaiscala/domain/responsesapi/JsonFormatsSpecs.scala
@@ -1463,7 +1463,11 @@ class JsonFormatsSpecs extends AnyWordSpecLike with Matchers {
         error = None,
         id = "resp_abc123",
         incompleteDetails = None,
-        instructions = Some("Act as a helpful assistant"),
+        instructions = Some(Seq(
+          Message.InputContent(Seq(
+            InputMessageContent.Text("Act as a helpful assistant")
+          ), ChatRole.User)
+        )),
         maxOutputTokens = Some(1000),
         metadata = Some(Map("key1" -> "value1", "key2" -> "value2")),
         model = "gpt-4o",
@@ -1738,6 +1742,100 @@ class JsonFormatsSpecs extends AnyWordSpecLike with Matchers {
           |}""".stripMargin,
         Pretty,
         justSemantics = true
+      )
+
+      // Response with instructions as Array (from Reusable prompt response)
+      val responseWithInstructionsAsArray = response.copy(
+        instructions = Some(Seq(
+          Message.InputContent(Seq(InputMessageContent.Text("Act as a helpful assistant")), ChatRole.System),
+          Message.InputContent(Seq(InputMessageContent.File(fileId = Some("fileId"))), ChatRole.User)
+        ))
+      )
+
+      testCodec[Response](
+        responseWithInstructionsAsArray,
+        """{
+          |  "created_at" : 1620000000,
+          |  "id" : "resp_abc123",
+          |  "instructions" : [
+          |    {
+          |      "type" : "message",
+          |      "content" : [ {
+          |        "type" : "input_text",
+          |        "text" : "Act as a helpful assistant"
+          |      } ],
+          |      "role" : "system"
+          |    }
+          |    ,
+          |    {
+          |      "type" : "message",
+          |      "content" : [ {
+          |        "type" : "input_file",
+          |        "file_id" : "fileId"
+          |      } ],
+          |      "role" : "user"
+          |    }
+          |   ],
+          |  "max_output_tokens" : 1000,
+          |  "metadata" : {
+          |    "key1" : "value1",
+          |    "key2" : "value2"
+          |  },
+          |  "model" : "gpt-4o",
+          |  "output" : [ {
+          |    "content" : [ {
+          |      "annotations" : [ ],
+          |      "text" : "Hello, how can I help you today?",
+          |      "type" : "output_text"
+          |    } ],
+          |    "id" : "output_def456",
+          |    "status" : "completed",
+          |    "type" : "message"
+          |  } ],
+          |  "parallel_tool_calls" : true,
+          |  "reasoning" : {
+          |    "effort" : "medium"
+          |  },
+          |  "status" : "completed",
+          |  "temperature" : 0.7,
+          |  "text" : {
+          |    "format" : {
+          |      "type" : "text"
+          |    }
+          |  },
+          |  "tool_choice" : "auto",
+          |  "tools" : [ {
+          |    "name" : "get_weather",
+          |    "parameters" : {
+          |      "properties" : {
+          |        "location" : {
+          |          "description" : "The city and state, e.g. San Francisco, CA",
+          |          "type" : "string"
+          |        }
+          |      },
+          |      "required" : [ "location" ],
+          |      "type" : "object"
+          |    },
+          |    "strict" : false,
+          |    "description" : "Get the current weather for a location",
+          |    "type" : "function"
+          |  } ],
+          |  "top_p" : 0.9,
+          |  "truncation" : "auto",
+          |  "usage" : {
+          |    "input_tokens" : 50,
+          |    "input_tokens_details" : {
+          |      "cached_tokens" : 50
+          |    },
+          |    "output_tokens" : 150,
+          |    "output_tokens_details" : {
+          |      "reasoning_tokens" : 75
+          |    },
+          |    "total_tokens" : 200
+          |  },
+          |  "user" : "user123"
+          |}""".stripMargin,
+        Pretty
       )
     }
 


### PR DESCRIPTION
This is a fix for issue #103 .

I added support for the 'instructions' in Responses so that it supports either null, a String, or an array of Messages, the latter being the expected response when you https://api.openai.com/v1/responses with a Reusable Prompt.

In this PR, I change the Response case class itself, add the new Json parsing to support this variable field type and extend a test to verify it parses both the String and the Array correctly.