### PR TITLE
Add MiniMax provider settings, direct model ids, and endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In addition to OpenAI, this library supports many other LLM providers. For provi
 | [Google Vertex AI](https://cloud.google.com/vertex-ai) | Full                   | Yes                               | Yes                     | Gemini models |
 | [Grok](https://x.ai/) | Full                   |                                   |                         | x.AI models |
 | [Groq](https://wow.groq.com/) | Only JSON object mode  |                                   | Yes                     | Fast inference |
+| [MiniMax](https://www.minimax.io/) | Only JSON object mode  |                                   |                         | Chinese provider (global & China) |
 | [Mistral](https://mistral.ai/) | Only JSON object mode  |                                   |                         | Open-source leader |
 | [Novita](https://novita.ai/) | Only JSON object mode  |                                   |                         | Cloud provider |
 | [Octo AI](https://octo.ai/) | Only JSON object mode  |                                   |                         | Cloud provider (obsolete) |
@@ -281,6 +282,23 @@ or with streaming
 ```scala
   val service = OpenAIChatCompletionServiceFactory.withStreaming(
     coreUrl = "http://localhost:11434/v1/"
+  )
+```
+
+15. [MiniMax](https://www.minimax.io/) - requires `MINIMAX_API_KEY`
+```scala
+  // global endpoint
+  val service = OpenAIChatCompletionServiceFactory(ChatProviderSettings.minimax)
+  // or with streaming
+  val service = OpenAIChatCompletionServiceFactory.withStreaming(ChatProviderSettings.minimax)
+
+  // China endpoint (api.minimaxi.com)
+  val chinaService = OpenAIChatCompletionServiceFactory(ChatProviderSettings.minimaxChina)
+```
+   MiniMax also exposes an Anthropic-compatible endpoint, reachable via the Anthropic client's escape hatch:
+```scala
+  val anthropicService = AnthropicServiceFactory.customInstance(
+    coreUrl = "https://api.minimax.io/anthropic/" // or "https://api.minimaxi.com/anthropic/" for China
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -297,8 +297,13 @@ or with streaming
 ```
    MiniMax also exposes an Anthropic-compatible endpoint, reachable via the Anthropic client's escape hatch:
 ```scala
+  import io.cequence.wsclient.domain.WsRequestContext
+
   val anthropicService = AnthropicServiceFactory.customInstance(
-    coreUrl = "https://api.minimax.io/anthropic/" // or "https://api.minimaxi.com/anthropic/" for China
+    coreUrl = "https://api.minimax.io/anthropic/v1/", // or "https://api.minimaxi.com/anthropic/v1/" for China
+    requestContext = WsRequestContext(
+      authHeaders = Seq(("Authorization", s"Bearer ${sys.env("MINIMAX_API_KEY")}"))
+    )
   )
 ```
 

--- a/openai-core/src/main/scala/io/cequence/openaiscala/domain/NonOpenAIModelId.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/domain/NonOpenAIModelId.scala
@@ -328,6 +328,9 @@ object NonOpenAIModelId {
   val sambanova_minimax_m2 = "MiniMax-M2" // SambaNova
   val sambanova_minimax_m2_5 = "MiniMax-M2.5" // SambaNova
   val sambanova_minimax_m2_7 = "MiniMax-M2.7" // SambaNova
+  // MiniMax direct API (api.minimax.io / api.minimaxi.com) - official model ids
+  val minimax_m3 = "MiniMax-M3" // MiniMax
+  val minimax_m2_7 = "MiniMax-M2.7" // MiniMax
   val moonshotai_kimi_k2_instruct = "moonshotai/kimi-k2-instruct" // Groq
   // context 262,144
   val moonshotai_kimi_k2_instruct_0905 = "moonshotai/kimi-k2-instruct-0905"

--- a/openai-core/src/main/scala/io/cequence/openaiscala/service/ChatProviderSettings.scala
+++ b/openai-core/src/main/scala/io/cequence/openaiscala/service/ChatProviderSettings.scala
@@ -19,4 +19,8 @@ object ChatProviderSettings {
   val geminiCoreURL = "https://generativelanguage.googleapis.com/v1beta/"
   val gemini = ProviderSettings(s"${geminiCoreURL}openai/", "GOOGLE_API_KEY")
   val novita = ProviderSettings("https://api.novita.ai/v3/openai/", "NOVITA_API_KEY")
+  // MiniMax direct API, OpenAI-compatible endpoints (requires MINIMAX_API_KEY).
+  // `minimax` is the global endpoint, `minimaxChina` the China (minimaxi.com) endpoint.
+  val minimax = ProviderSettings("https://api.minimax.io/v1/", "MINIMAX_API_KEY")
+  val minimaxChina = ProviderSettings("https://api.minimaxi.com/v1/", "MINIMAX_API_KEY")
 }

--- a/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ChatCompletionProvider.scala
+++ b/openai-examples/src/main/scala/io/cequence/openaiscala/examples/ChatCompletionProvider.scala
@@ -117,6 +117,20 @@ object ChatCompletionProvider {
     implicit ec: ExecutionContext
   ): OpenAIChatCompletionStreamedService = provide(ChatProviderSettings.novita)
 
+  /**
+   * MiniMax global endpoint. Requires `MINIMAX_API_KEY`
+   */
+  def minimax(
+    implicit ec: ExecutionContext
+  ): OpenAIChatCompletionStreamedService = provide(ChatProviderSettings.minimax)
+
+  /**
+   * MiniMax China endpoint. Requires `MINIMAX_API_KEY`
+   */
+  def minimaxChina(
+    implicit ec: ExecutionContext
+  ): OpenAIChatCompletionStreamedService = provide(ChatProviderSettings.minimaxChina)
+
   private def provide(
     settings: ProviderSettings
   )(


### PR DESCRIPTION
Reason: MiniMax was only reachable through reseller model ids; this adds first-class MiniMax provider settings, direct model ids, and docs for its global and China endpoints.

## What this changes

- **`ChatProviderSettings`**: adds two OpenAI-compatible MiniMax entries in the existing provider registry — `minimax` (global, `https://api.minimax.io/v1/`) and `minimaxChina` (China, `https://api.minimaxi.com/v1/`), both keyed off `MINIMAX_API_KEY`, following the same shape as the existing provider entries.
- **`ChatCompletionProvider`** (examples): adds `minimax` and `minimaxChina` convenience factories mirroring the other providers.
- **`NonOpenAIModelId`**: registers the official direct-API model ids `MiniMax-M3` and `MiniMax-M2.7` under the MiniMax section (previously only reseller-prefixed ids existed).
- **`README.md`**: adds MiniMax to the provider table and a usage entry, including a note that MiniMax's Anthropic-compatible endpoint is reachable through the existing `AnthropicServiceFactory.customInstance` escape hatch (global and China base URLs).

The change only adds new registry values, factory methods, and documentation; it follows the established patterns and does not alter any existing behavior.

## Checks

No build or test was run: this environment has no JVM/sbt toolchain available. The change consists solely of additive registry entries, factory methods, and documentation that mirror the surrounding code line-for-line.
